### PR TITLE
Enhance about and home page styling

### DIFF
--- a/src/pages/About.css
+++ b/src/pages/About.css
@@ -81,6 +81,34 @@
   animation: fadeInUp 1s ease-out 0.6s both;
 }
 
+.about-hero-highlights {
+  position: absolute;
+  bottom: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  width: min(90%, 720px);
+  z-index: 2;
+}
+
+.about-hero-badge {
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.5rem 1.25rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.4px;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #fff;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 12px 30px rgba(13, 110, 253, 0.25);
+  animation: float 6s ease-in-out infinite;
+}
+
 .scroll-indicator {
   position: absolute;
   bottom: 30px;
@@ -97,6 +125,57 @@
   background: linear-gradient(135deg, #f8f9fa 0%, #e9ecef 100%);
   position: relative;
   overflow: hidden;
+}
+
+.impact-stats-backdrop {
+  position: absolute;
+  inset: -60px 0 -40px 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 1;
+}
+
+.impact-backdrop-glow {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.6;
+}
+
+.impact-backdrop-glow.glow-one {
+  top: -10%;
+  left: 12%;
+  width: 360px;
+  height: 360px;
+  background: rgba(13, 110, 253, 0.45);
+  animation: impactDrift 16s ease-in-out infinite;
+}
+
+.impact-backdrop-glow.glow-two {
+  bottom: -15%;
+  right: 8%;
+  width: 420px;
+  height: 420px;
+  background: rgba(102, 16, 242, 0.45);
+  animation: impactDrift 20s ease-in-out infinite reverse;
+}
+
+.impact-backdrop-ring {
+  position: absolute;
+  top: 12%;
+  left: 50%;
+  width: 68%;
+  height: 68%;
+  transform: translateX(-50%);
+  border: 1px solid rgba(255, 255, 255, 0.45);
+  border-radius: 50%;
+  opacity: 0.4;
+  animation: impactPulse 14s ease-in-out infinite;
+}
+
+.impact-stats-section .container {
+  position: relative;
+  z-index: 2;
 }
 
 .impact-stats-section::before {
@@ -143,6 +222,11 @@
   position: relative;
   overflow: hidden;
   margin-bottom: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  isolation: isolate;
 }
 
 .impact-card::before {
@@ -165,6 +249,19 @@
   height: 8px;
 }
 
+.impact-card-backdrop {
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 20% 20%, var(--card-color-rgba, rgba(13, 110, 253, 0.25)), transparent 70%);
+  opacity: 0;
+  transition: opacity 0.4s ease;
+  z-index: 1;
+}
+
+.impact-card:hover .impact-card-backdrop {
+  opacity: 1;
+}
+
 .impact-number {
   font-size: 4rem;
   font-weight: 800;
@@ -185,21 +282,55 @@
   text-transform: uppercase;
 }
 
+.impact-icon {
+  font-size: 2rem;
+  width: 60px;
+  height: 60px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: linear-gradient(135deg, rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0.2));
+  box-shadow: 0 12px 30px rgba(13, 110, 253, 0.15);
+  position: relative;
+  z-index: 2;
+}
+
+.impact-description {
+  margin: 0;
+  font-size: 1rem;
+  color: #495057;
+  max-width: 260px;
+  line-height: 1.6;
+  position: relative;
+  z-index: 2;
+}
+
+.impact-card .impact-number,
+.impact-card .impact-label {
+  position: relative;
+  z-index: 2;
+}
+
 /* Color Variables for Impact Cards */
 .impact-card.primary {
   --card-color: #0d6efd;
+  --card-color-rgba: rgba(13, 110, 253, 0.25);
 }
 
 .impact-card.success {
   --card-color: #198754;
+  --card-color-rgba: rgba(25, 135, 84, 0.25);
 }
 
 .impact-card.info {
   --card-color: #0dcaf0;
+  --card-color-rgba: rgba(13, 202, 240, 0.25);
 }
 
 .impact-card.warning {
   --card-color: #ffc107;
+  --card-color-rgba: rgba(255, 193, 7, 0.28);
 }
 
 /* Enhanced Initiatives Section */
@@ -363,6 +494,15 @@
     font-size: 3.5rem;
   }
 
+  .about-hero-highlights {
+    bottom: 70px;
+  }
+
+  .about-hero-badge {
+    font-size: 0.8rem;
+    padding: 0.45rem 1.1rem;
+  }
+
   .impact-stats-title,
   .initiatives-title {
     font-size: 2.5rem;
@@ -380,6 +520,16 @@
 
   .about-hero-description {
     font-size: 1.1rem;
+  }
+
+  .about-hero-highlights {
+    bottom: 60px;
+    width: min(95%, 520px);
+    gap: 0.85rem;
+  }
+
+  .about-hero-badge {
+    font-size: 0.78rem;
   }
 
   .impact-card {
@@ -415,6 +565,16 @@
 
   .about-hero-description {
     font-size: 1rem;
+  }
+
+  .about-hero-highlights {
+    bottom: 55px;
+    gap: 0.65rem;
+  }
+
+  .about-hero-badge {
+    font-size: 0.72rem;
+    padding: 0.4rem 0.9rem;
   }
 
   .impact-stats-section,
@@ -461,6 +621,18 @@
     font-size: 1.1rem;
   }
 
+  .about-hero-highlights {
+    bottom: 45px;
+    width: calc(100% - 2rem);
+    padding: 0 0.5rem;
+    gap: 0.6rem;
+  }
+
+  .about-hero-badge {
+    flex: 1 1 48%;
+    text-align: center;
+  }
+
   .impact-stats-title,
   .initiatives-title,
   .mission-vision-title {
@@ -502,6 +674,33 @@
   }
   60% {
     transform: translateY(-5px) translateX(-50%);
+  }
+}
+
+@keyframes impactDrift {
+  0% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    transform: translate3d(40px, -20px, 0) scale(1.05);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+}
+
+@keyframes impactPulse {
+  0% {
+    transform: translateX(-50%) scale(0.95);
+    opacity: 0.35;
+  }
+  50% {
+    transform: translateX(-50%) scale(1);
+    opacity: 0.5;
+  }
+  100% {
+    transform: translateX(-50%) scale(0.95);
+    opacity: 0.35;
   }
 }
 

--- a/src/pages/About.js
+++ b/src/pages/About.js
@@ -7,6 +7,11 @@ const About = () => {
   const [impactNumbers, setImpactNumbers] = useState({});
 
   const heroBackgroundImage = '/NSS_about_photo.jpg';
+  const heroHighlights = [
+    'Community-Centric Projects',
+    'Leadership & Service Learning',
+    'Sustainable Rural Impact'
+  ];
 
   const initiatives = [
     {
@@ -114,47 +119,64 @@ const About = () => {
       number: 5,
       label: 'Villages Adopted',
       color: 'primary',
-      duration: 1500
+      duration: 1500,
+      icon: '🏡',
+      description: 'Long-term partnerships with adopted villages for holistic growth.'
     },
     {
       number: 1000,
       suffix: '+',
       label: 'Trees Planted',
       color: 'success',
-      duration: 2000
+      duration: 2000,
+      icon: '🌳',
+      description: 'Sustainable plantation drives led by dedicated volunteers.'
     },
     {
       number: 50,
       suffix: '+',
       label: 'Annual Events',
       color: 'info',
-      duration: 1500
+      duration: 1500,
+      icon: '📅',
+      description: 'Workshops, health camps, drives and awareness programs each year.'
     },
     {
       number: 5000,
       suffix: '+',
       label: 'Lives Impacted',
       color: 'warning',
-      duration: 2500
+      duration: 2500,
+      icon: '🤝',
+      description: 'Beneficiaries reached through our community and campus initiatives.'
     }
   ];
 
   // Counter Component
-  const CountUpNumber = ({ endNumber, duration, suffix = '', color, label, index }) => {
+  const CountUpNumber = ({ endNumber, duration, suffix = '', color, label, index, icon, description }) => {
     const [count, setIsVisible] = useCountUp(endNumber, duration);
 
+    const shouldAnimate = impactNumbers[index];
+
     useEffect(() => {
-      if (impactNumbers[index]) {
+      if (shouldAnimate) {
         setIsVisible(true);
       }
-    }, [impactNumbers, index, setIsVisible]);
+    }, [shouldAnimate, setIsVisible]);
 
     return (
       <div className={`impact-card ${color}`} data-index={index}>
+        <div className="impact-card-backdrop" aria-hidden="true" />
+        {icon && (
+          <div className="impact-icon" aria-hidden="true">{icon}</div>
+        )}
         <div className="impact-number">
           {count}{suffix}
         </div>
         <div className="impact-label">{label}</div>
+        {description && (
+          <p className="impact-description">{description}</p>
+        )}
       </div>
     );
   };
@@ -176,6 +198,13 @@ const About = () => {
             We believe in creating positive change through dedicated service to society.
           </p>
         </div>
+        <div className="about-hero-highlights">
+          {heroHighlights.map((highlight) => (
+            <span className="about-hero-badge" key={highlight}>
+              {highlight}
+            </span>
+          ))}
+        </div>
         <div className="scroll-indicator">
           <ChevronDown size={32} />
         </div>
@@ -183,7 +212,12 @@ const About = () => {
 
       {/* Enhanced Impact Stats Section */}
       <section className="impact-stats-section">
-        <div className="container">
+        <div className="impact-stats-backdrop" aria-hidden="true">
+          <span className="impact-backdrop-glow glow-one" />
+          <span className="impact-backdrop-glow glow-two" />
+          <span className="impact-backdrop-ring" />
+        </div>
+        <div className="container position-relative">
           <h2 className="impact-stats-title fade-in-up">Our Impact</h2>
           <div className="row g-4">
             {impactData.map((item, index) => (
@@ -195,6 +229,8 @@ const About = () => {
                   color={item.color}
                   label={item.label}
                   index={index}
+                  icon={item.icon}
+                  description={item.description}
                 />
               </div>
             ))}

--- a/src/pages/HomePage.css
+++ b/src/pages/HomePage.css
@@ -65,6 +65,32 @@
   background: linear-gradient(45deg, #6610f2, #0d6efd);
 }
 
+.hero-highlights {
+  margin-top: 2rem;
+  display: flex;
+  gap: 1rem;
+  justify-content: center;
+  flex-wrap: wrap;
+  width: min(90%, 720px);
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.hero-pill {
+  background: rgba(255, 255, 255, 0.18);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  border-radius: 999px;
+  padding: 0.45rem 1.2rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  font-weight: 600;
+  color: #fff;
+  backdrop-filter: blur(10px);
+  box-shadow: 0 12px 24px rgba(13, 110, 253, 0.25);
+  animation: float 7s ease-in-out infinite;
+}
+
 /* Enhanced Stats Section */
 .stats-section {
   padding: 5rem 0;
@@ -84,6 +110,53 @@
   pointer-events: none;
 }
 
+.stats-backdrop {
+  position: absolute;
+  inset: -80px 0 -60px 0;
+  pointer-events: none;
+  overflow: hidden;
+  z-index: 1;
+}
+
+.stats-glow {
+  position: absolute;
+  border-radius: 50%;
+  filter: blur(120px);
+  opacity: 0.55;
+}
+
+.stats-glow-one {
+  top: -15%;
+  left: 5%;
+  width: 320px;
+  height: 320px;
+  background: rgba(13, 110, 253, 0.5);
+  animation: statsDrift 18s ease-in-out infinite;
+}
+
+.stats-glow-two {
+  bottom: -20%;
+  right: 12%;
+  width: 400px;
+  height: 400px;
+  background: rgba(102, 16, 242, 0.45);
+  animation: statsDrift 20s ease-in-out infinite reverse;
+}
+
+.stats-grid {
+  position: absolute;
+  inset: 15% 18%;
+  border: 1px solid rgba(255, 255, 255, 0.4);
+  border-radius: 32px;
+  opacity: 0.5;
+  backdrop-filter: blur(2px);
+}
+
+.stats-section .container {
+  position: relative;
+  z-index: 2;
+}
+
 .stats-card {
   background: rgba(255, 255, 255, 0.9);
   backdrop-filter: blur(10px);
@@ -94,6 +167,11 @@
   transition: all 0.3s ease;
   position: relative;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  isolation: isolate;
 }
 
 .stats-card::before {
@@ -107,6 +185,16 @@
   transition: all 0.3s ease;
 }
 
+.stats-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 25% 20%, rgba(13, 110, 253, 0.2), transparent 70%);
+  opacity: 0;
+  transition: opacity 0.3s ease;
+  z-index: 1;
+}
+
 .stats-card:hover {
   transform: translateY(-10px);
   box-shadow: 0 20px 40px rgba(0, 0, 0, 0.15);
@@ -114,6 +202,10 @@
 
 .stats-card:hover::before {
   height: 6px;
+}
+
+.stats-card:hover::after {
+  opacity: 1;
 }
 
 .stats-number {
@@ -139,6 +231,13 @@
   margin-bottom: 1rem;
   color: #0d6efd;
   filter: drop-shadow(0 4px 8px rgba(13, 110, 253, 0.2));
+}
+
+.stats-card .stats-icon,
+.stats-card .stats-number,
+.stats-card .stats-label {
+  position: relative;
+  z-index: 2;
 }
 
 /* Card Animations */
@@ -434,6 +533,15 @@
     font-size: 3rem;
   }
 
+  .hero-highlights {
+    gap: 0.85rem;
+  }
+
+  .hero-pill {
+    font-size: 0.8rem;
+    padding: 0.4rem 1rem;
+  }
+
   .stats-section {
     padding: 4rem 0;
   }
@@ -446,6 +554,15 @@
 
   .hero-subtitle {
     font-size: 1.1rem;
+  }
+
+  .hero-highlights {
+    margin-top: 1.5rem;
+    gap: 0.75rem;
+  }
+
+  .hero-pill {
+    font-size: 0.78rem;
   }
 
   .stats-card {
@@ -475,6 +592,16 @@
   .hero-cta-button {
     padding: 0.8rem 2rem;
     font-size: 1rem;
+  }
+
+  .hero-highlights {
+    margin-top: 1.25rem;
+    gap: 0.6rem;
+  }
+
+  .hero-pill {
+    font-size: 0.72rem;
+    padding: 0.35rem 0.9rem;
   }
 
   .stats-section {
@@ -522,6 +649,17 @@
 @media (max-width: 576px) {
   .hero-title {
     font-size: 1.75rem;
+  }
+
+  .hero-highlights {
+    margin-top: 1rem;
+    gap: 0.5rem;
+    justify-content: center;
+  }
+
+  .hero-pill {
+    font-size: 0.68rem;
+    padding: 0.3rem 0.75rem;
   }
 
   .hero-cta-button {
@@ -605,6 +743,18 @@
   }
   100% {
     transform: scale(1);
+  }
+}
+
+@keyframes statsDrift {
+  0% {
+    transform: translate3d(0, 0, 0) scale(0.95);
+  }
+  50% {
+    transform: translate3d(30px, -20px, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(0, 0, 0) scale(0.95);
   }
 }
 

--- a/src/pages/HomePage.js
+++ b/src/pages/HomePage.js
@@ -43,6 +43,12 @@ const HomePage = () => {
     },
   ];
 
+  const heroHighlights = [
+    'Community Outreach',
+    'Leadership in Action',
+    'Sustainable Impact'
+  ];
+
   const [eventReports, setEventReports] = useState([]);
 
   useEffect(() => {
@@ -137,7 +143,7 @@ const HomePage = () => {
       setCurrentSlide((prev) => (prev + 1) % heroImages.length);
     }, 5000);
     return () => clearInterval(timer);
-  }, []);
+  }, [heroImages.length]);
 
   // Intersection Observer for animations
   useEffect(() => {
@@ -302,6 +308,13 @@ const HomePage = () => {
               >
                 Join NSS Today
               </button>
+              <div className="hero-highlights">
+                {heroHighlights.map((highlight) => (
+                  <span className="hero-pill" key={highlight}>
+                    {highlight}
+                  </span>
+                ))}
+              </div>
             </div>
           </div>
         ))}
@@ -309,7 +322,12 @@ const HomePage = () => {
 
       {/* Enhanced Stats Section */}
       <section className="stats-section">
-        <div className="container">
+        <div className="stats-backdrop" aria-hidden="true">
+          <span className="stats-glow stats-glow-one" />
+          <span className="stats-glow stats-glow-two" />
+          <span className="stats-grid" />
+        </div>
+        <div className="container position-relative">
           <div className="row g-4">
             <div className="col-md-4">
               <div className="stats-card h-100 text-center fade-in-up">


### PR DESCRIPTION
## Summary
- add hero highlight badges and glassmorphism impact cards to the About page along with a decorative backdrop for statistics
- enrich homepage hero and statistics sections with animated accents and responsive chips to match the refreshed design

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cc31682aac8331baa1815f618f32a0